### PR TITLE
[tw-select] Various small bug fixes involving multi-select

### DIFF
--- a/projects/ng-tw/package.json
+++ b/projects/ng-tw/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ng-tw",
-	"version": "0.0.16",
+	"version": "0.0.17",
 	"peerDependencies": {
 		"@angular/common": ">=15.0.0",
 		"@angular/core": ">=15.0.0",

--- a/projects/ng-tw/src/modules/select/select.component.html
+++ b/projects/ng-tw/src/modules/select/select.component.html
@@ -19,7 +19,7 @@
     class="block truncate"
     [ngClass]="{'block': hasValue()}"
     [hidden]="!hasValue()">
-    {{ innerValues.length + " selected" }}
+    {{ this.innerValues.length }} selected
 </span>
 
 <style>

--- a/projects/ng-tw/src/modules/select/select.component.html
+++ b/projects/ng-tw/src/modules/select/select.component.html
@@ -14,13 +14,21 @@
     [hidden]="!hasValue()"
 ></span>
 
-<span
-    *ngIf="_multiple"
-    class="block truncate"
-    [ngClass]="{'block': hasValue()}"
-    [hidden]="!hasValue()">
-    {{ this.innerValues.length }} selected
-</span>
+<ng-container *ngIf="_multiple">
+    <span *ngIf="this.innerValues.length === this.options.length"
+          class="block truncate"
+          [ngClass]="{'block': hasValue()}"
+          [hidden]="!hasValue()">
+        All selected
+    </span>
+
+    <span *ngIf="this.innerValues.length !== this.options.length"
+          class="block truncate"
+          [ngClass]="{'block': hasValue()}"
+          [hidden]="!hasValue()">
+        {{ this.innerValues.length }} selected
+    </span>
+</ng-container>
 
 <style>
     .custom-arrow:empty {

--- a/projects/ng-tw/src/modules/select/select.component.ts
+++ b/projects/ng-tw/src/modules/select/select.component.ts
@@ -283,8 +283,10 @@ export class SelectComponent implements ControlValueAccessor, OnInit, AfterConte
 
         //
         // Carry over selected options
+        const newValues: any[] = [];
         this.options.forEach(opt => {
             if (oldValues.find((oldValue: any) => this.compareWith(opt.value, oldValue))) {
+                newValues.push(opt.value);
                 opt.selected = true;
             } else {
                 opt.selected = false;
@@ -293,8 +295,8 @@ export class SelectComponent implements ControlValueAccessor, OnInit, AfterConte
 
         //
         // Emit the new selected values.
-        this.innerValues = oldValues;
-        this.onChange(oldValues);
+        this.innerValues = newValues;
+        this.onChange(newValues);
 
         //
         // Update manager active item

--- a/projects/ng-tw/src/modules/select/select.component.ts
+++ b/projects/ng-tw/src/modules/select/select.component.ts
@@ -276,6 +276,7 @@ export class SelectComponent implements ControlValueAccessor, OnInit, AfterConte
      * Handler for when the options of select component change (only for use in multi forms).
      */
     newOptionsSet(oldValues: any, innerHTML: string | null, touched: boolean, forceUpdate = false) {
+
         //
         // Skip if we don't have options
         if (!this.options) {
@@ -467,7 +468,11 @@ export class SelectComponent implements ControlValueAccessor, OnInit, AfterConte
 
         this._keyManager.change.pipe().subscribe(() => {
             if (!this.isOpen && this._keyManager.activeItem) {
-                this._keyManager.activeItem.selectViaInteraction();
+                if (! this._multiple) {
+                    // TODO causes a bug in multi-selects where the first item is (de)selected on init
+                    this._keyManager.activeItem.selectViaInteraction();
+                }
+
             }
         });
     }

--- a/projects/ng-tw/src/modules/select/select.component.ts
+++ b/projects/ng-tw/src/modules/select/select.component.ts
@@ -193,6 +193,7 @@ export class SelectComponent implements ControlValueAccessor, OnInit, AfterConte
                 this._multiple
                     ? this.newOptionsSet(this.innerValues, null, false, true)
                     : this.selectOption(this.innerValue, null ,false, true);
+                this.cdr.markForCheck();
             });
         });
     }

--- a/projects/ng-tw/src/modules/select/select.component.ts
+++ b/projects/ng-tw/src/modules/select/select.component.ts
@@ -418,10 +418,6 @@ export class SelectComponent implements ControlValueAccessor, OnInit, AfterConte
         if (isUserInput === true) {
             this.markAsTouched();
         }
-
-        //
-        // Update manager active item
-        this._updateKeyManagerActiveItem(source.value);
     }
 
     handleKeydown(event: KeyboardEvent) {


### PR DESCRIPTION
Fixes a few bugs to do with multi-selects:

- Shows a nicer message in the multi-select box when it isn't open
- The use of key manager was automatically de-selecting the first item in a multi-select. This has been disabled for now, but for accessibility reasons we might want to fix this in the future
- Selecting an option doesn't set it to be the active option in a multi-select. This behaviour makes sense in a single select, but not in a multi-select.
- When a multi select's options change, this can effect the current selection. Add a call to run the change detector again (analogous to what happens after a selection event).
- When a multi select's options change, only select the options which were contained in the multi-select before the change.